### PR TITLE
Remove redundant DATABASE_URI assignment

### DIFF
--- a/api/anubis/config.py
+++ b/api/anubis/config.py
@@ -12,7 +12,6 @@ class Config:
         self.SECRET_KEY = os.environ.get("SECRET_KEY", default="DEBUG")
 
         # sqlalchemy
-        self.SQLALCHEMY_DATABASE_URI = None
         self.SQLALCHEMY_POOL_PRE_PING = True
         self.SQLALCHEMY_POOL_SIZE = 100
         self.SQLALCHEMY_POOL_RECYCLE = 280


### PR DESCRIPTION
Two `self.SQLALCHEMY_DATABASE_URI` assignment are written. The redundant one is removed.