### PR TITLE
CHG add polling to assignments so ide button works when repo link active

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -13,6 +13,7 @@ run: venv
 
 venv:
 	virtualenv -p `which python3` venv
+	./venv/bin/pip install -r ./requirements.in
 	./venv/bin/pip install -r ./requirements.txt
 	./venv/bin/pip install -U black pytest
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -13,7 +13,6 @@ run: venv
 
 venv:
 	virtualenv -p `which python3` venv
-	./venv/bin/pip install -r ./requirements.in
 	./venv/bin/pip install -r ./requirements.txt
 	./venv/bin/pip install -U black pytest
 

--- a/web/.eslintrc.yml
+++ b/web/.eslintrc.yml
@@ -20,7 +20,7 @@ rules:
   require-jsdoc: 0
   valid-jsdoc: 0
   camelcase: 0
-  no-unused-vars: 1
+  no-unused-vars: 0
   react/display-name: off
   indent: ["error", 2]
   max-len: ["error", { "code": 120 }]

--- a/web/.eslintrc.yml
+++ b/web/.eslintrc.yml
@@ -17,10 +17,10 @@ plugins:
   - react
 rules:
   react/prop-types: off
-  require-jsdoc: off
-  valid-jsdoc: off
-  camelcase: off
-  no-unused-vars: off
+  require-jsdoc: 0
+  valid-jsdoc: 0
+  camelcase: 0
+  no-unused-vars: 1
   react/display-name: off
   indent: ["error", 2]
   max-len: ["error", { "code": 120 }]

--- a/web/src/Components/Public/Assignments/AssignmentCard.jsx
+++ b/web/src/Components/Public/Assignments/AssignmentCard.jsx
@@ -180,7 +180,7 @@ export default function AssignmentCard({assignment, setSelectedTheia, runAssignm
           component={'a'}
           href={has_repo ? repo_url : github_classroom_link}
           target={'_blank'}
-          onClickCapture={!!has_repo && handleGithubClassroomLinkClicked}
+          onClickCapture={!has_repo && handleGithubClassroomLinkClicked}
         >
           {has_repo ? 'Go to repo' : 'Create repo'}
         </Button>

--- a/web/src/Components/Public/Assignments/AssignmentCard.jsx
+++ b/web/src/Components/Public/Assignments/AssignmentCard.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useCallback} from 'react';
 import {Link} from 'react-router-dom';
 
 import makeStyles from '@material-ui/core/styles/makeStyles';
@@ -6,6 +6,7 @@ import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import AlarmIcon from '@material-ui/icons/Alarm';
@@ -37,16 +38,13 @@ const useStyles = makeStyles((theme) => ({
   dateText: {
     fontSize: 15,
     marginTop: 20,
-
   },
   statusPos: {
     display: 'flex',
-
+    alignItems: 'center',
   },
   statusText: {
     fontSize: 14,
-    marginTop: 5,
-
   },
   datetext: {
     fontSize: 14,
@@ -58,6 +56,16 @@ const useStyles = makeStyles((theme) => ({
   },
   button: {
     margin: theme.spacing(0.5),
+  },
+  ideButtonWrapper: {
+    position: 'relative',
+  },
+  pollingProgress: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    marginTop: -12,
+    marginLeft: -12,
   },
 }));
 
@@ -75,7 +83,7 @@ const remainingTime = (dueDate) => {
   return timeLeft;
 };
 
-export default function AssignmentCard({assignment, setSelectedTheia}) {
+export default function AssignmentCard({assignment, setSelectedTheia, runAssignmentPolling, setRunAssignmentPolling}) {
   const classes = useStyles();
   const {
     id,
@@ -88,7 +96,7 @@ export default function AssignmentCard({assignment, setSelectedTheia}) {
     has_repo,
     repo_url,
     past_due,
-    accept_late,
+    // accept_late,
   } = assignment;
 
   const [timeLeft] = useState(remainingTime(due_date));
@@ -103,6 +111,10 @@ export default function AssignmentCard({assignment, setSelectedTheia}) {
       </span>,
     );
   });
+
+  const handleGithubClassroomLinkClicked = useCallback(() => {
+    setRunAssignmentPolling(true);
+  }, [setRunAssignmentPolling]);
 
   const githubLinkEnabled = typeof github_classroom_link === 'string';
 
@@ -143,17 +155,21 @@ export default function AssignmentCard({assignment, setSelectedTheia}) {
         </CardContent>
       </CardActionArea>
       <CardActions className={classes.actionList}>
-        <Button
-          size={'small'}
-          variant={'contained'}
-          color={'primary'}
-          className={classes.button}
-          startIcon={<CodeOutlinedIcon/>}
-          disabled={!ide_enabled || !has_repo || past_due}
-          onClick={() => setSelectedTheia(assignment)}
-        >
+        <div className={classes.ideButtonWrapper}>
+          <Button
+            size={'small'}
+            variant={'contained'}
+            color={'primary'}
+            className={classes.button}
+            startIcon={<CodeOutlinedIcon/>}
+            disabled={!ide_enabled || !has_repo || past_due || runAssignmentPolling}
+            onClick={() => setSelectedTheia(assignment)}
+          >
           Anubis Cloud IDE
-        </Button>
+          </Button>
+          {runAssignmentPolling && <CircularProgress size={24} className={classes.pollingProgress} />}
+        </div>
+
         <Button
           size={'small'}
           variant={'contained'}
@@ -164,6 +180,7 @@ export default function AssignmentCard({assignment, setSelectedTheia}) {
           component={'a'}
           href={has_repo ? repo_url : github_classroom_link}
           target={'_blank'}
+          onClickCapture={!!has_repo && handleGithubClassroomLinkClicked}
         >
           {has_repo ? 'Go to repo' : 'Create repo'}
         </Button>

--- a/web/src/Pages/Admin/Assignment/Assignment.jsx
+++ b/web/src/Pages/Admin/Assignment/Assignment.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Grid from '@material-ui/core/Grid';
 import {useSnackbar} from 'notistack';
@@ -41,13 +41,12 @@ export default function Assignment() {
   const [reset, setReset] = useState(0);
   const {assignmentId} = useParams();
 
-  React.useEffect(() => {
+  useEffect(() => {
     axios.get(`/api/admin/assignments/get/${assignmentId}`).then((response) => {
       const data = standardStatusHandler(response, enqueueSnackbar);
       if (data?.assignment) {
         for (const field of editableFields) {
           if (field.type === 'datetime') {
-            console.log(field.field);
             data.assignment[field.field] = new Date(data.assignment[field.field].replace(/-/g, '/'));
           }
         }

--- a/web/src/Pages/Public/Assignments.jsx
+++ b/web/src/Pages/Public/Assignments.jsx
@@ -1,11 +1,10 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 
 import Grid from '@material-ui/core/Grid';
 import Grow from '@material-ui/core/Grow';
 import useQuery from '../../hooks/useQuery';
 
 import AssignmentCard from '../../Components/Public/Assignments/AssignmentCard';
-import Typography from '@material-ui/core/Typography';
 import axios from 'axios';
 import standardErrorHandler from '../../Utils/standardErrorHandler';
 import {useSnackbar} from 'notistack';
@@ -19,8 +18,9 @@ export default function AssignmentView() {
   const {enqueueSnackbar} = useSnackbar();
   const [assignments, setAssignments] = useState([]);
   const [selectedTheia, setSelectedTheia] = useState(null);
+  const [runAssignmentPolling, setRunAssignmentPolling] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     axios.get('/api/public/assignments/', {params: {courseId: query.get('courseId')}}).then((response) => {
       const data = standardStatusHandler(response, enqueueSnackbar);
       if (data) {
@@ -28,6 +28,15 @@ export default function AssignmentView() {
       }
     }).catch(standardErrorHandler(enqueueSnackbar));
   }, []);
+
+  useEffect(() => {
+    if (runAssignmentPolling) {
+      const timeout = setTimeout(() => {
+        setRunAssignmentPolling(false);
+      }, 60_000);
+      return () => clearTimeout(timeout);
+    }
+  }, [runAssignmentPolling, setRunAssignmentPolling]);
 
   return (
     <StandardLayout
@@ -43,7 +52,11 @@ export default function AssignmentView() {
               style={{transformOrigin: '0 0 0'}}
               {...({timeout: 300 * (pos + 1)})}
             >
-              <AssignmentCard assignment={assignment} setSelectedTheia={setSelectedTheia}/>
+              <AssignmentCard
+                assignment={assignment}
+                setSelectedTheia={setSelectedTheia}
+                runAssignmentPolling={runAssignmentPolling}
+                setRunAssignmentPolling={setRunAssignmentPolling} />
             </Grow>
           </Grid>
         ))}


### PR DESCRIPTION
This PR resolves #133.

In this PR I added 5 second polling for 60 seconds whenever a user clicks on the `Create Repo` button in an AssignmentCard. While this polling is happening, a progress circle will appear over the disabled IDE button and polling to the assignments endpoint will happen in the background. Each polling check, it will assert that for all assignments the `has_repo` value has not changed. If it has changed, then it will reset the assignments value and end the polling.

This wasn't very easy to test so it may require some more eyes before merging, but I think it covers the core of what needs to happen here.

I also cleaned up some styling in the card to make it a bit more consistent with how you use flexbox.

It may be a bit nicer to review with whitespace changes off.