### PR TITLE
FIX potential issue with polling

### DIFF
--- a/web/src/Components/Public/Assignments/AssignmentCard.jsx
+++ b/web/src/Components/Public/Assignments/AssignmentCard.jsx
@@ -83,7 +83,13 @@ const remainingTime = (dueDate) => {
   return timeLeft;
 };
 
-export default function AssignmentCard({assignment, setSelectedTheia, runAssignmentPolling, setRunAssignmentPolling}) {
+export default function AssignmentCard({
+  assignment,
+  setSelectedTheia,
+  runAssignmentPolling,
+  setRunAssignmentPolling,
+  setPollingAssignmentId,
+}) {
   const classes = useStyles();
   const {
     id,
@@ -114,7 +120,8 @@ export default function AssignmentCard({assignment, setSelectedTheia, runAssignm
 
   const handleGithubClassroomLinkClicked = useCallback(() => {
     setRunAssignmentPolling(true);
-  }, [setRunAssignmentPolling]);
+    setPollingAssignmentId(id);
+  }, [setRunAssignmentPolling, setPollingAssignmentId, id]);
 
   const githubLinkEnabled = typeof github_classroom_link === 'string';
 

--- a/web/src/Pages/Public/Assignments.jsx
+++ b/web/src/Pages/Public/Assignments.jsx
@@ -19,6 +19,7 @@ export default function AssignmentView() {
   const [assignments, setAssignments] = useState([]);
   const [selectedTheia, setSelectedTheia] = useState(null);
   const [runAssignmentPolling, setRunAssignmentPolling] = useState(false);
+  const [pollingAssignmentId, setPollingAssignmentId] = useState(null);
 
   useEffect(() => {
     axios.get('/api/public/assignments/', {params: {courseId: query.get('courseId')}}).then((response) => {
@@ -41,13 +42,9 @@ export default function AssignmentView() {
 
           if (data) {
             // compare assignments to see if any have a corresponding repo now
-            const assignmentsHasChanged = !assignments.every((assignment) => {
-              const matchingResponseAssignment = data.assignments.find((a) => a.id === assignment.id);
+            const currentPollingAssignment = data.assignments.find((a) => a.id === pollingAssignmentId);
 
-              return assignment.has_repo === matchingResponseAssignment.has_repo;
-            });
-
-            if (assignmentsHasChanged) {
+            if (currentPollingAssignment.has_repo) {
               setAssignments(data.assignments);
               setRunAssignmentPolling(false);
             }
@@ -60,7 +57,7 @@ export default function AssignmentView() {
         clearInterval(runPollingInterval);
       };
     }
-  }, [runAssignmentPolling, setRunAssignmentPolling]);
+  }, [runAssignmentPolling, setRunAssignmentPolling, pollingAssignmentId]);
 
   return (
     <StandardLayout
@@ -79,8 +76,10 @@ export default function AssignmentView() {
               <AssignmentCard
                 assignment={assignment}
                 setSelectedTheia={setSelectedTheia}
-                runAssignmentPolling={runAssignmentPolling}
-                setRunAssignmentPolling={setRunAssignmentPolling} />
+                runAssignmentPolling={assignment.id === pollingAssignmentId && runAssignmentPolling}
+                setRunAssignmentPolling={setRunAssignmentPolling}
+                setPollingAssignmentId={setPollingAssignmentId}
+              />
             </Grow>
           </Grid>
         ))}


### PR DESCRIPTION
In my PR last night I added polling to the assignments to wait for the github repo to be created when `create repo` is clicked. What I had forgotten was that, if there were several assignments each one would appear as loading while we await the successful repo creation. 

This fix lets us keep track of the current polling assignment's ID so that we keep track of only one specific has repo value and only one assignment card shows up as loading when we are polling.

I tested this by allowing any assignment to be set to polling and then if it has a repo the polling should end after 5 seconds. If it doesn't it should await that cards repo url.