### PR TITLE
CHG same domain theia

### DIFF
--- a/api/anubis/config.py
+++ b/api/anubis/config.py
@@ -49,7 +49,6 @@ class Config:
         self.LOGGER_NAME = os.environ.get("LOGGER_NAME", default="anubis-api")
 
         # Theia
-        self.THEIA_DOMAIN = os.environ.get("THEIA_DOMAIN", default="ide.anubis.osiris.services")
         self.THEIA_TIMEOUT = timedelta(hours=6)
 
         # autograding specific config

--- a/api/anubis/utils/lms/theia.py
+++ b/api/anubis/utils/lms/theia.py
@@ -51,9 +51,7 @@ def theia_redirect_url(theia_session_id: str, netid: str) -> str:
     """
     scheme = 'https' if not is_debug() else 'http'
 
-    return "{}://{}/initialize?token={}&anubis=1".format(
-        scheme,
-        config.THEIA_DOMAIN,
+    return "/ide/initialize?token={}&anubis=1".format(
         create_token(netid, session_id=theia_session_id),
     )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
       - "MINDEBUG=0"
       - "DEBUG=1"
       - "DB_HOST=db"
-      - "THEIA_DOMAIN=ide.localhost"
       - "MIGRATE=1"
     volumes:
       - "./api:/opt/app"

--- a/k8s/chart/templates/api.yml
+++ b/k8s/chart/templates/api.yml
@@ -86,14 +86,11 @@ spec:
             secretKeyRef:
               name: api
               key: database-uri
-
         - name: "REDIS_PASS"
           valueFrom:
             secretKeyRef:
               name: api
               key: redis-password
-        - name: "THEIA_DOMAIN"
-          value: {{ .Values.theia.proxy.domain | quote }}
         {{- if .Values.api.healthCheck }}
         livenessProbe:
           httpGet:

--- a/k8s/chart/templates/ingress.yml
+++ b/k8s/chart/templates/ingress.yml
@@ -14,6 +14,21 @@ spec:
   stripPrefix:
     prefixes:
       - "/api"
+---
+# Strip prefix /api
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-ide
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: anubis
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+spec:
+  stripPrefix:
+    prefixes:
+      - "/ide"
 
 ---
 apiVersion: traefik.containo.us/v1alpha1
@@ -106,7 +121,10 @@ spec:
   {{- end }}
   routes:
   - kind: Rule
-    match: Host(`{{ .Values.theia.proxy.domain }}`)
+    match: Host(`{{ .Values.domain }}`) && PathPrefix(`/ide`)
+    middlewares:
+    - name: strip-ide
+      namespace: {{ .Release.Namespace }}
     services:
     - name: anubis-theia-proxy
       port: 5000

--- a/k8s/chart/templates/rpc.yml
+++ b/k8s/chart/templates/rpc.yml
@@ -10,15 +10,14 @@ metadata:
 {{- if .Values.imagePullSecret }}
 imagePullSecrets:
   - name: {{ .Values.imagePullSecret }}
-{{- end }}
 ---
+{{- end }}
 
 {{- range $.Values.rpc.queues }}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: anubis-rpc-default
+  name: anubis-rpc-{{ . }}
   namespace: {{ $.Release.Namespace }}
   labels:
     app.kubernetes.io/name: rpc-{{ . }}
@@ -78,10 +77,10 @@ spec:
               name: api
               key: database-host
         - name: "DATABASE_URI"
-         valueFrom:
-           secretKeyRef:
-             name: api
-             key: database-uri
+          valueFrom:
+            secretKeyRef:
+              name: api
+              key: database-uri
         - name: "REDIS_PASS"
           valueFrom:
             secretKeyRef:
@@ -95,7 +94,6 @@ spec:
 ---
 {{- end }}
 
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -44,7 +44,6 @@ theia:
   enable: true
   proxy:
     replicas: 1
-    domain: "ide.anubis.osiris.services"
     image: "registry.digitalocean.com/anubis/theia-proxy"
     tag: "latest"
 
@@ -72,4 +71,4 @@ puller:
   image: "registry.digitalocean.com/anubis/puller"
   tag: "latest"
   imagePullSecret: "anubis"
-  command: ['registry.digitalocean.com/anubis/theia-xv6', 'registry.digitalocean.com/anubis/theia-admin', 'registry.digitalocean.com/anubis/api']
+  command: ['registry.digitalocean.com/anubis/theia-xv6', 'registry.digitalocean.com/anubis/theia-admin']

--- a/k8s/debug/provision.sh
+++ b/k8s/debug/provision.sh
@@ -5,7 +5,7 @@ cd $(dirname $0)
 cd ..
 
 # Stop if any command has an error
-set -e
+set -ex
 
 echo 'This script will provision a minikube cluster for debugging'
 
@@ -82,22 +82,22 @@ kubectl create namespace anubis
 # here.
 echo 'Adding mariadb'
 helm upgrade --install mariadb bitnami/mariadb \
+    --set 'fullnameOverride=mariadb' \
     --set 'auth.rootPassword=anubis' \
     --set 'volumePermissions.enabled=true' \
     --set 'auth.username=anubis' \
     --set 'auth.database=anubis' \
     --set 'auth.password=anubis' \
-    --set 'fullnameOverride=anubis' \
     --set 'architecture=standalone' \
     --namespace anubis
 
 # Install a minimal redis deployment
 echo 'Adding redis'
 helm upgrade --install redis bitnami/redis \
-    --set fullnameOverride=redis \
-    --set global.redis.password=anubis \
-    --set architecture=standalone \
-    --set master.persistence.enabled=false \
+    --set 'fullnameOverride=redis' \
+    --set 'auth.password=anubis' \
+    --set 'architecture=standalone' \
+    --set 'master.persistence.enabled=false' \
     --namespace anubis
 
 if [ -f debug/init-secrets.sh ]; then

--- a/k8s/prod/Makefile
+++ b/k8s/prod/Makefile
@@ -134,10 +134,11 @@ redis: ns-anubis
 		--namespace anubis
 
 api-secret:
-	@if ! kubectl get secret api -n anubis; then;
+	@if ! kubectl get secret api -n anubis; then \
 		kubectl create secret generic api \
 			--namespace anubis \
 			--from-literal=database-uri=mysql+pymysql://anubis:$(DB_PASS)@mariadb.anubis.svc.cluster.local/anubis \
+			--from-literal=database-host=mariadb.anubis.svc.cluster.local \
 			--from-literal=database-password=$(DB_PASS) \
 			--from-literal=redis-password=$(REDIS_PASS) \
 			--from-literal=secret-key=$(SECRET_KEY); \

--- a/theia/ide/xv6/Dockerfile
+++ b/theia/ide/xv6/Dockerfile
@@ -41,7 +41,8 @@ RUN set -ex; \
     gcc-multilib g++-multilib \
     python3 python3-pip \
     clangd-12 \
-    qemu-system-i386; \
+    qemu-system-i386 \
+    libsecret-1-0; \
   pip3 install --no-cache-dir supervisor; \
   ln -s /usr/bin/clangd-12 /usr/bin/clangd; \
   echo 'set auto-load safe-path /' > /home/theia/.gdbinit \

--- a/theia/proxy/index.js
+++ b/theia/proxy/index.js
@@ -91,7 +91,7 @@ const initialize = (req, res, url, query) => {
     session_id: query_token.session_id,
   }, SECRET_KEY, {expiresIn: '6h'});
   res.writeHead(302, {
-    location: '/', "Set-Cookie": `token=${signed_token}; Max-Age=${6 * 3600}; HttpOnly`
+    location: '/ide/', "Set-Cookie": `token=${signed_token}; Max-Age=${6 * 3600}; HttpOnly`
   })
   res.end('redirecting...')
 };


### PR DESCRIPTION
We will need to figure out how to configure theia to run on a different base url path. Something like `anubis.osiris.services/ide/proxy` would probably work fine.

We would probably then need to configure the theia builds [here](https://github.com/GusSand/Anubis/blob/ac364d6708b9ec4cbf6ae6c0f24474e25dc05145/theia/ide/xv6/latest.package.json) and [here](https://github.com/GusSand/Anubis/blob/ac364d6708b9ec4cbf6ae6c0f24474e25dc05145/theia/ide/xv6/latest.package.json). Then we would need to remove the [THEIA_DOMAIN](https://github.com/GusSand/Anubis/blob/ac364d6708b9ec4cbf6ae6c0f24474e25dc05145/api/anubis/config.py#L42) config, and replace it with something like `DOMAIN`.

Then quite seperately we would need to change the theia proxy [IngressRoute](https://github.com/GusSand/Anubis/blob/ac364d6708b9ec4cbf6ae6c0f24474e25dc05145/k8s/chart/templates/ingress.yml#L90) definition 
