### PR TITLE
FIX jepst Dockerfile bashrc to right place

### DIFF
--- a/theia/ide/jepst/Dockerfile
+++ b/theia/ide/jepst/Dockerfile
@@ -54,8 +54,6 @@ RUN set -ex; \
   pip3 install --no-cache-dir supervisor; \
   ln -s /usr/bin/clangd-12 /usr/bin/clangd; \
   cd /home/anubis; \
-  echo 'cat /etc/motd' >> /home/anubis/.bashrc; \
-  echo 'alias python=python3' >> /home/anubis/.bashrc; \
   mkdir -p /opt/anubis/.theia; \
   echo '{"terminal.integrated.shell.linux": "/bin/bash"}' \
     > /opt/anubis/.theia/settings.json; \

--- a/theia/ide/jepst/Dockerfile
+++ b/theia/ide/jepst/Dockerfile
@@ -54,8 +54,8 @@ RUN set -ex; \
   pip3 install --no-cache-dir supervisor; \
   ln -s /usr/bin/clangd-12 /usr/bin/clangd; \
   cd /home/anubis; \
-  echo 'cat /etc/motd' >> /etc/skel/.bashrc; \
-  echo 'alias python=python3' >> /etc/skel/.bashrc; \
+  echo 'cat /etc/motd' >> /home/anubis/.bashrc; \
+  echo 'alias python=python3' >> /home/anubis/.bashrc; \
   mkdir -p /opt/anubis/.theia; \
   echo '{"terminal.integrated.shell.linux": "/bin/bash"}' \
     > /opt/anubis/.theia/settings.json; \

--- a/theia/init/entrypoint.sh
+++ b/theia/init/entrypoint.sh
@@ -22,6 +22,7 @@ done
 if ! grep '/etc/motd' /out/.bashrc; then
     echo "adding motd to bashrc"
     echo "" >> /out/.bashrc
+    echo "alias python=python3" >> /out/.bashrc
     echo "cat /etc/motd" >> /out/.bashrc
 else
     echo "skipping adding motd to bashrc"


### PR DESCRIPTION
Commands echoed to student bashrc were going to the copy in /etc, not the student's home directory