### PR TITLE
RM debug code in Lectures.jsx

### DIFF
--- a/web/src/Pages/Public/Lectures.jsx
+++ b/web/src/Pages/Public/Lectures.jsx
@@ -40,8 +40,6 @@ export default function Repos() {
     }).catch(standardErrorHandler(enqueueSnackbar));
   }, []);
 
-  console.log(lectures);
-
   const get_href = (row) => (
     `${window.location.origin}/api/public/static${row.static_file.path}/${row.static_file.filename}`
   );


### PR DESCRIPTION
Remove debug code that prints `lectures` to the console.