### PR TITLE
FIX Floating-point calculation in provision.sh

### DIFF
--- a/k8s/debug/provision.sh
+++ b/k8s/debug/provision.sh
@@ -21,7 +21,7 @@ if uname -a | grep -i linux &> /dev/null; then
     # On linux, we can use the standard unix commands for
     # getting the core and memory resources
     CPUS=$(( $(nproc) / 2 ))
-    MEM="$(( $(free -h | nice grep -i 'mem' | awk '{print substr($2, 1, length($2)-2)}') / 2 ))Gi"
+    MEM="$( echo "$(free -h | nice grep -i 'mem' | awk '{print substr($2, 1, length($2)-2)}') / 2" | bc -l )Gi"
 else
     # On MacOS, we'll need to calculate the CPUs and cores
     # using sysctl. nproc and free are too cool for MacOS


### PR DESCRIPTION
Line 24 in `k8s/debug/provision.sh` will not work in bash as bash does not support floating-point calculations. I changed that line and now the calculation is done using `bc`.