### PR TITLE
CHG Configure k8s secrets during provision

### DIFF
--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -181,8 +181,10 @@ make mkdebug
 ```
 
 There is also a special script that is called when provisioning the minikube cluster. The purpose of it
-is to place any kubernetes secret create commands that you may need. Place that script at `k8s/debug/init-secrets.sh`.
-The file will be gitignored, but be extra sure you do not commit it on accident.
+is to place any kubernetes secret create commands that you may need. To configure it, copy the content from
+`k8s/debug/init-secrets-template.sh` to `k8s/debug/init-secrets.sh` and edit the secrets. It will be
+created automatically using the defaults if you haven't done so already. The file will be gitignored,
+but be extra sure you do not commit it on accident.
 
 The startup links for the minikube debug environment work exactly the same as with the debug and mindebug environments.
 When you have a change that you want to push to the minikube cluster you can run the `./k8s/debug/restart.sh` script. It

--- a/k8s/debug/init-secrets-template.sh
+++ b/k8s/debug/init-secrets-template.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# COPY the content to init-secrets.sh and configure the secrets before deployment.
+# The file will be gitignored, but be extra sure you do not commit it on accident.
+
+# Create the api configuration secrets
+kubectl create secret generic api \
+    --from-literal=database-uri=mysql+pymysql://anubis:anubis@mariadb.anubis.svc.cluster.local/anubis \
+    --from-literal=database-host=mariadb.anubis.svc.cluster.local \
+    --from-literal=database-password=anubis \
+    --from-literal=database-port=3306 \
+    --from-literal=redis-password=anubis \
+    --from-literal=secret-key=$(head -c10 /dev/urandom | openssl sha1 -hex | awk '{print $2}') \
+    --namespace anubis
+
+# Create the oauth configuration secrets
+kubectl create secret generic oauth \
+    --from-literal=consumer-key='aaa' \
+    --from-literal=consumer-secret='aaa' \
+    --namespace anubis
+
+# Create the git user secrets
+kubectl create secret generic git \
+    --from-literal=token='token' \
+    --from-literal=credentials='https://your-robot:token@github.com' \
+    --namespace anubis

--- a/k8s/debug/provision.sh
+++ b/k8s/debug/provision.sh
@@ -105,21 +105,6 @@ if [ -f debug/init-secrets.sh ]; then
     bash debug/init-secrets.sh
 fi
 
-kubectl create secret generic api \
-    --from-literal=database-uri=mysql+pymysql://anubis:anubis@mariadb.anubis.svc.cluster.local/anubis \
-    --from-literal=database-host=mariadb.anubis.svc.cluster.local \
-    --from-literal=database-password=anubis \
-    --from-literal=database-port=3306 \
-    --from-literal=redis-password=anubis \
-    --from-literal=secret-key=$(head -c10 /dev/urandom | openssl sha1 -hex | awk '{print $2}') \
-    --namespace anubis
-
-# Create the oauth configuration secrets
-kubectl create secret generic oauth \
-    --from-literal=consumer-key='aaa' \
-    --from-literal=consumer-secret='aaa' \
-    --namespace anubis
-
 # Run the debug.sh script to build, then install all the stuff
 # for anubis.
 exec ./debug/restart.sh

--- a/k8s/debug/provision.sh
+++ b/k8s/debug/provision.sh
@@ -9,6 +9,13 @@ set -ex
 
 echo 'This script will provision a minikube cluster for debugging'
 
+# Check if init-secrets.sh has been created. If not, we create it from the
+# defaults configured in the template.
+if [ ! -f debug/init-secrets.sh ]; then
+    echo "k8s/debug/init-secrets.sh is not found. Creating it from the template..."
+    sed 's/COPY.*/Edit the content below to configure the secrets\./' debug/init-secrets-template.sh > debug/init-secrets.sh
+fi
+
 # Delete the minikube cluster if one exists
 minikube delete
 
@@ -101,9 +108,10 @@ helm upgrade --install redis bitnami/redis \
     --set 'master.persistence.enabled=false' \
     --namespace anubis
 
-if [ -f debug/init-secrets.sh ]; then
-    bash debug/init-secrets.sh
-fi
+# The defaults in init-secrets-template.sh will be used when init-secrets
+# does not present.
+echo 'Adding kubernetes secrets'
+bash debug/init-secrets.sh
 
 # Run the debug.sh script to build, then install all the stuff
 # for anubis.


### PR DESCRIPTION
Previously, we needed to create `k8s/debug/init-secrets.sh` manually before running `make mkdebug`.
Otherwise, there would be 503 errors due to missing `git` secrets.

This PR automates the process and creates a template to guide contributors/deployers
configuring the necessary secrets for the mkdebug setup. It also offers us a cleaner way
to manage secrets (or any secrets to be added) in the future.

Fixes #261.
<!--
Before submitting a pull request, please read
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#pull-requests

Commit message formatting guidelines:
https://github.com/GusSand/Anubis/blob/HEAD/.github/CONTRIBUTING.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Include with development environment you are using.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
